### PR TITLE
Uri (full support for all git repository URLs)

### DIFF
--- a/pride-git-support/src/main/groovy/com/prezi/gradle/pride/vcs/git/GitVcsSupport.groovy
+++ b/pride-git-support/src/main/groovy/com/prezi/gradle/pride/vcs/git/GitVcsSupport.groovy
@@ -68,22 +68,22 @@ class GitVcsSupport implements VcsSupport {
 
 	@Override
 	String resolveRepositoryName(String repositoryUrl) {
-        try {
-            // check if the user supplied argument is a repository
-            // an exception is thrown if it is not
-            def commandLine = ["git", "ls-remote", repositoryUrl]
-            def process = ProcessUtils.executeIn(null, commandLine, false)
-        } catch ( PrideException ex ) {
-            // user supplied argument isn't a repo. return null so it will be tried as a module name
-            return null
-        }
-        // user supplied argument is a repo
-        // try to extract the module name and return it if successful
-        def m = repositoryUrl =~ /^.*?([-\._\w]+?)(?:\.git)?\\/?$/
-        if (m) {
-            return m[0][1]
-        } else {
-            return null
-        }
+		try {
+			// check if the user supplied argument is a repository
+			// an exception is thrown if it is not
+			def commandLine = ["git", "ls-remote", repositoryUrl]
+			def process = ProcessUtils.executeIn(null, commandLine, false)
+		} catch ( PrideException ex ) {
+			// user supplied argument isn't a repo. return null so it will be tried as a module name
+			return null
+		}
+		// user supplied argument is a repo
+		// try to extract the module name and return it if successful
+		def m = repositoryUrl =~ /^.*?([-\._\w]+?)(?:\.git)?\\/?$/
+		if (m) {
+			return m[0][1]
+		} else {
+			return null
+		}
 	}
 }


### PR DESCRIPTION
The resolveRepositoryName method of GitVcsSupport was modified to support all get repository URIs. This was done by calling "git ls-remote" with the user specified URI from the command line argument (unmodified). If this command succeeds then the URI is used unchanged. If the command fails, then it is assumed that that the URI is relative to the repository base URI.
