### PR TITLE
initialize from existing pride without the modules in place

### DIFF
--- a/pride/src/main/java/com/prezi/gradle/pride/cli/commands/actions/InitActionFromImportedConfig.java
+++ b/pride/src/main/java/com/prezi/gradle/pride/cli/commands/actions/InitActionFromImportedConfig.java
@@ -51,7 +51,7 @@ public class InitActionFromImportedConfig extends InitActionBase {
 		Collection<String> moduleNames = Collections2.transform(modulesFromConfiguration, new Function<Module, String>() {
 			@Override
 			public String apply(Module module) {
-				return module.getName();
+				return module.getRemote();
 			}
 		});
 		List<String> failedModules = ModuleAdder.addModules(pride, moduleNames, vcsManager);


### PR DESCRIPTION
I've set up a pride with 14 modules in it and wanted to share this project in a separate git repo with my coworkers. However I failed to initialize it without the actual modules in place. 

With this patch I can do this and initialize the pride in place from the config:

```
pride init --from-config .pride/config -f
```

I had to change module.getName() to module.getRemote() because it failed to add my modules based only on their name.
