### PR TITLE
Use URL property of svn info output of a module

### DIFF
--- a/pride-svn-support/src/main/java/com/prezi/pride/vcs/svn/SvnVcsSupport.java
+++ b/pride-svn-support/src/main/java/com/prezi/pride/vcs/svn/SvnVcsSupport.java
@@ -30,7 +30,7 @@ public class SvnVcsSupport implements VcsSupport {
 				+ "/?"										// optional trailing slash
 				+ "$", Pattern.COMMENTS);
 	private static final Pattern REVISION = Pattern.compile("Revision: (.*)");
-	private static final Pattern ROOT_URL = Pattern.compile("Repository Root: (.*)");
+	private static final Pattern URL = Pattern.compile("URL: (.*)");
 
 	private static final Logger log = LoggerFactory.getLogger(SvnVcsSupport.class);
 
@@ -109,7 +109,7 @@ public class SvnVcsSupport implements VcsSupport {
 	}
 
 	private RepositoryUrl getRepositoryUrlInternal(File targetDirectory) throws IOException {
-		String fullUrl = getInfoValue(targetDirectory, ROOT_URL);
+		String fullUrl = getInfoValue(targetDirectory, URL);
 		return RepositoryUrl.fromString(fullUrl);
 	}
 


### PR DESCRIPTION
Solution to #135
The "pride list" command uses internally "svn info" to determine the status of a module. Instead of the Reporitory Root property of the output of "svn info", the URL property of the output is used.