### PR TITLE
Do not throw IOException when a module cannot be removed

### DIFF
--- a/pride-core/src/main/java/com/prezi/pride/Pride.java
+++ b/pride-core/src/main/java/com/prezi/pride/Pride.java
@@ -165,7 +165,16 @@ public class Pride {
 		final File moduleDir = getModuleDirectory(name);
 		logger.info("Removing " + name + " from " + moduleDir);
 		modules.remove(name);
-		FileUtils.deleteDirectory(moduleDir);
+		try {
+			FileUtils.deleteDirectory(moduleDir);
+		}
+		catch (IOException ex) {
+			// Found on Windows only, sometimes files cannot be deleted
+			// This can be due to background processes monitoring the filesystem or
+			// the user left a command shell open in the folder
+			logger.error("Removing " + name + " failed with error: " + ex.getMessage());
+			logger.error("Please remove folder " + moduleDir + " manually");
+		}
 	}
 
 	public boolean hasModule(String name) {


### PR DESCRIPTION
On a Windows system the "pride remove <module>" command can fail when a file or directory of the module is in use. This is possible when using software that monitors file system activity like a virus scanner or TortoiseSVN. The problem also occurs when command shell is open in one of the subfolders of the module. The IOException that was raised before resulted in a corrupted pride workspace. 

Now, the IOException is handled and a message is logged to the user to manually remove the folder.

Solves #134 